### PR TITLE
Change client.list to resolve with Contents value of S3 response object

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -10,7 +10,7 @@ module.exports = function list(client, prefix){
 
   client.list({ prefix: prefix }, headers, function(err, data){
     if(err) return deferred.reject(err);
-    deferred.resolve(data.Content);
+    deferred.resolve(data.Contents);
   });
 
   return deferred.promise;

--- a/lib/list.js
+++ b/lib/list.js
@@ -10,7 +10,7 @@ module.exports = function list(client, prefix){
 
   client.list({ prefix: prefix }, headers, function(err, data){
     if(err) return deferred.reject(err);
-    deferred.resolve(data);
+    deferred.resolve(data.Content);
   });
 
   return deferred.promise;


### PR DESCRIPTION
Client.copy expects client.list to resolve with an array of file objects, but client.list resolves with an S3 response; the file objects are stored in the "Contents" property of that response. This pull request would modify client.list to resolve with the "Contents" value of that response, i.e. resolve with an array of file objects directly.
